### PR TITLE
Rename env variables

### DIFF
--- a/lib/forki/scrapers/scraper.rb
+++ b/lib/forki/scrapers/scraper.rb
@@ -68,7 +68,7 @@ module Forki
 
       visit("/")  # Visit the Facebook home page
       fill_in("email", with: ENV["FACEBOOK_EMAIL"])
-      fill_in("pass", with: ENV["FACEBOOK_PW"])
+      fill_in("pass", with: ENV["FACEBOOK_PASSWORD"])
       click_button("Log In")
       sleep 3
     end

--- a/lib/forki/scrapers/scraper.rb
+++ b/lib/forki/scrapers/scraper.rb
@@ -67,8 +67,8 @@ module Forki
       return if current_url.include? "facebook"
 
       visit("/")  # Visit the Facebook home page
-      fill_in("email", with: ENV["FB_EMAIL"])
-      fill_in("pass", with: ENV["FB_PW"])
+      fill_in("email", with: ENV["FACEBOOK_EMAIL"])
+      fill_in("pass", with: ENV["FACEBOOK_PW"])
       click_button("Log In")
       sleep 3
     end


### PR DESCRIPTION
This changes the environment variable names from `FB_EMAIL` and
`FB_PW` TO `FACEBOOK_EMAIL` and `FACEBOOK_PASSWORD`.

The reasoning for this is to make it clearer when this gem is used in
other projects. Abbreviations can be *just* confusing enough.
