### PR TITLE
Move Capybara Intialization To Class

### DIFF
--- a/lib/forki/scrapers/scraper.rb
+++ b/lib/forki/scrapers/scraper.rb
@@ -7,14 +7,16 @@ require "oj"
 require "selenium-webdriver"
 require "open-uri"
 
-Capybara.default_driver = :selenium_chrome
-Capybara.app_host = "https://facebook.com"
-Capybara.default_max_wait_time = 15
-
 module Forki
 
   class Scraper
     include Capybara::DSL
+
+    def initialize
+      Capybara.default_driver = :selenium_chrome
+      Capybara.app_host = "https://facebook.com"
+      Capybara.default_max_wait_time = 15
+    end
 
     # Yeah, just use the tmp/ directory that's created during setup
     def download_image(img_elem)


### PR DESCRIPTION
This moves the Capybara initiliaztion to the scraper class initializer.
The reason for this is so that it can live next to other gems that also
use Capybara without overwriting the setting on accident by just being
included in a Gemfile.